### PR TITLE
Task/filter mutation input by auth

### DIFF
--- a/README-DIRECTIVE-FIELD-AUTH.md
+++ b/README-DIRECTIVE-FIELD-AUTH.md
@@ -2,6 +2,8 @@
 
 The `@fieldAuth` directive is used to specify the authorisation rules associated with the a field on a specific type.  This directive is used in conjunction with the `authorisationStructure` settings in the `autographcraft.config.js` file.
 
+The format of the `@fieldAuth` directive closely follows that of the `@modelAuth` directive. This documentation extends the [@modelAuth Directive Documentation](./README-DIRECTIVE-MODEL-AUTH.md) and they should be used in conjunction with each other.
+
 This documentation is created for the purpose of explaining the functionality of the `@fieldAuth` directive and should not be considered a guide on best practice for authorisation within your application.
 
 ## Directive Specification
@@ -57,57 +59,58 @@ type User
 }
 ```
 
-On the specified model `User` there is a field called `userOnlyReadField`.  This field has been annotated with the `@fieldAuth` directive.  If you need more information on the `@modelAuth` directive, see the [Model Auth Directive Documentation](./README-DIRECTIVE-MODEL-AUTH.md).
+On the specified model `User` there is a field called `userOnlyReadField`.  This field has been annotated with the `@fieldAuth` directive.  If you need more information on the `@modelAuth` directive, see the [@modelAuth Directive Documentation](./README-DIRECTIVE-MODEL-AUTH.md).
 
 The `@fieldAuth` directive specifies that only the `User` this model represents can read the `userOnlyReadField` field.  All other callers will receive `null` when querying this field.  Because this field is only readable by the `User` represented by the document, the field must be nullable so that the `null` value can be returned to other callers.
 
 Adding the `@fieldAuth` directive to a field will not affect the visibility of the field in the GraphQL schema.  The field will still be visible to all callers on the GraphQL introspection query, but only the authorised callers will be able to read or write to the field.
 
-Adding the `fieldAuth` directive to a field will remove the functionality of the `@modelAuth` directives on the type.  The `@fieldAuth` directive will take precedence over the `@modelAuth` directive.  This means that if a field has a `@fieldAuth` directive, the `@modelAuth` directives will be ignored for that field and any methods specified in the `@modelAuth` directive will not be available to the caller unless they are also specified in a `@fieldAuth` directive for the field.
-
-<!-- TODO: CONTINUE HERE -->
-
-<!-- 
-**`type Post`**
+Adding the `fieldAuth` directive to a field will remove the functionality of the `@modelAuth` directives on the type.  The `@fieldAuth` directive will take precedence over the `@modelAuth` directive.  This means that if a field has a `@fieldAuth` directive, the `@modelAuth` directives will be ignored for that field and any methods specified in the `@modelAuth` directive will not be available to the caller unless they are also specified in a `@fieldAuth` directive for the field.  For example:
 
 ```graphql
-@fieldAuth(
-  authorisingModel: "public"
-  methods: [read, list]
-)
+type User 
+  @model
+  @modelAuth(
+    authorisingModel: "User"
+    idField: "id"
+    methods: [read, update, delete, list]
+  ) 
+  @modelAuth(
+    authorisingModel: "admin"
+    methods: [all]
+  ) {
+  id: ID!
+
+  # Whoops! 
+  # The admin now has no access to this field because the @fieldAuth directive takes precedence over the @modelAuth directive
+  userOnlyReadField: String @fieldAuth(authorisingModel: "User", idField: "id", methods: [read]) 
+}
 ```
 
-This `@fieldAuth` directive defines that anyone who queries the application API will be able to call the `readPost` and `listPost` queries.
+This can be rectified by adding a `@fieldAuth` directive to the field that specifies the `admin` authorising model:
 
 ```graphql
-@fieldAuth(
-  authorisingModel: "User"
-  idField: "createdByUserId"
-  methods: [all]
-)
+type User 
+  @model
+  @modelAuth(
+    authorisingModel: "User"
+    idField: "id"
+    methods: [read, update, delete, list]
+  ) 
+  @modelAuth(
+    authorisingModel: "admin"
+    methods: [all]
+  ) {
+  id: ID!
+
+  # Phew! 
+  # The admin now has full access to this field again
+  userOnlyReadField: String
+    @fieldAuth(authorisingModel: "User", idField: "id", methods: [read]) 
+    @fieldAuth(authorisingModel: "admin", methods: [all]) 
+}
 ```
 
-This `@fieldAuth` directive defines that only the `User` who created the `Post` can perform any other methods on the `Post` (i.e. `createPost`, `updatePost`, `deletePost`).
+## Special Authorising Models
 
-**`type User`**
-
-```graphql
-@fieldAuth(
-  authorisingModel: "signedIn"
-  methods: [read, list]
-)
-```
-
-This `@fieldAuth` directive defines that the caller must be signed into the application to be able to read a `User`'s details.
-
-```graphql
-@fieldAuth(
-  authorisingModel: "User"
-  idField: "id"
-  methods: [read, update, delete, list]
-)
-```
-
-This `@fieldAuth` directive defines that a `User` is the only caller who can edit (`update`, `delete`) their details in the database.
-
-You will notice that there is no `create` method available on the `User` model via the `@fieldAuth` directives.  This is because it would not make sense for a user to be able create themselves.  Creation of `User`s would need to be done directly to the database via another method (such as the sign-up process). -->
+Details on the special authorising models can be found in the [@authModel Directive Documentation](./README-DIRECTIVE-MODEL-AUTH.md#special-authorising-models).

--- a/README-DIRECTIVE-MODEL-AUTH.md
+++ b/README-DIRECTIVE-MODEL-AUTH.md
@@ -1,5 +1,11 @@
 # `@modelAuth` Directive Documentation
 
+- [`@modelAuth` Directive Documentation](#modelauth-directive-documentation)
+  - [Directive Specification](#directive-specification)
+  - [Setting up Authorising Models](#setting-up-authorising-models)
+  - [Usage](#usage)
+  - [Special Authorising Models](#special-authorising-models)
+
 The `@modelAuth` directive is used to specify the authorisation rules associated with the type.  This directive is used in conjunction with the `authorisationStructure` settings in the `autographcraft.config.js` file.
 
 This documentation is created for the purpose of explaining the functionality of the `@modelAuth` directive and should not be considered a guide on best practice for authorisation within your application.
@@ -119,3 +125,32 @@ This `@modelAuth` directive defines that the caller must be signed into the appl
 This `@modelAuth` directive defines that a `User` is the only caller who can edit (`update`, `delete`) their details in the database.
 
 You will notice that there is no `create` method available on the `User` model via the `@modelAuth` directives.  This is because it would not make sense for a user to be able create themselves.  Creation of `User`s would need to be done directly to the database via another method (such as the sign-up process).
+
+## Special Authorising Models
+
+There are three (3) special authorising models that can be used with the `@modelAuth` directive:
+
+- `public`: This authorising model allows anyone to access the model.
+- `signedIn`: This authorising model allows signed-in users to access the model.
+- `admin`: This authorising model allows users with the `isAdmin` flag set to `true` on the context object to access the model.
+
+You cannot use these model names as the name of a model in the `autographcraft.config.js` file or as the name of a type in the schema.
+
+These special authorising models can be used in the `authorisingModel` parameter of the `@modelAuth` directive and must be done so without the `idField` parameter.
+
+```graphql
+@modelAuth(
+  authorisingModel: "public"
+  methods: [read, list]
+)
+
+@modelAuth(
+  authorisingModel: "signedIn"
+  methods: [read, list]
+)
+
+@modelAuth(
+  authorisingModel: "admin"
+  methods: [all]
+)
+```

--- a/examples/yogaServerWithMongoDb/index.ts
+++ b/examples/yogaServerWithMongoDb/index.ts
@@ -29,7 +29,7 @@ async function main() {
     mongooseConnection,
     logger: console,
     config,
-    authInitialisationData: { User: '673c462c7e4a338bdee980c8' },
+    authInitialisationData: { User: 'aaaabbbbccccddddeeeeffff' },
     isAdmin: false,
   };
 

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbBaseResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbBaseResolver.ts
@@ -79,10 +79,11 @@ export class MongoDbBaseResolver<ArgType, ReturnType> {
   }
 
   async getAndRunHooks(
+    resolverName: RESOLVER_NAME,
     hookPoint: HookInNames,
     databaseDocuments: ReturnType[] | null
   ): Promise<void> {
-    const hookIns = this.getHookIns(RESOLVER_NAME.READ, hookPoint);
+    const hookIns = this.getHookIns(resolverName, hookPoint);
     this.context.autographcraft.logger?.debug({
       [`${hookPoint}Hooks`]: hookIns,
     });

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbCreateResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbCreateResolver.ts
@@ -24,6 +24,16 @@ export class MongoDbCreateResolver<
     try {
       await this.getAndRunHooks(HookInNames.INITIAL, databaseDocument);
 
+      // Remove the unauthorised fields from the input object
+      const permittedFieldsForInput = await this._getPermittedFieldsForDocument(
+        this.context,
+        this.args.input as ReturnType
+      );
+      this.args.input = removeUnauthorisedFieldsFromDocument<ReturnType>(
+        this.args.input as ReturnType,
+        permittedFieldsForInput
+      ) as ArgType['input'];
+
       await this.getAndRunHooks(
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocument

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbCreateResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbCreateResolver.ts
@@ -22,7 +22,11 @@ export class MongoDbCreateResolver<
     let databaseDocument: ReturnType | null = null;
 
     try {
-      await this.getAndRunHooks(HookInNames.INITIAL, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
+        HookInNames.INITIAL,
+        databaseDocument
+      );
 
       // Remove the unauthorised fields from the input object
       const permittedFieldsForInput = await this._getPermittedFieldsForDocument(
@@ -35,6 +39,7 @@ export class MongoDbCreateResolver<
       ) as ArgType['input'];
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocument
       );
@@ -42,11 +47,13 @@ export class MongoDbCreateResolver<
       // No arg validation is required for create
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.POST_VALIDATE_ARGS,
         databaseDocument
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.PRE_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
@@ -62,11 +69,13 @@ export class MongoDbCreateResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.POST_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.PRE_DOCUMENT_AUTHORIZE,
         databaseDocument
       );
@@ -84,6 +93,7 @@ export class MongoDbCreateResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.POST_DOCUMENT_AUTHORIZE,
         databaseDocument
       );
@@ -91,29 +101,34 @@ export class MongoDbCreateResolver<
       // Convert the args to an instance of the database model
       const documentInstance = new this._databaseModel(this.args.input);
 
-      await this.getAndRunHooks(HookInNames.PRE_VALIDATE_DOCUMENT, [
-        documentInstance as ReturnType,
-      ]);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
+        HookInNames.PRE_VALIDATE_DOCUMENT,
+        [documentInstance as ReturnType]
+      );
 
       // Validate the document
       await documentInstance.validate();
 
-      await this.getAndRunHooks(HookInNames.POST_VALIDATE_DOCUMENT, [
-        documentInstance as ReturnType,
-      ]);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
+        HookInNames.POST_VALIDATE_DOCUMENT,
+        [documentInstance as ReturnType]
+      );
 
-      await this.getAndRunHooks(HookInNames.PRE_COMMIT, [
+      await this.getAndRunHooks(RESOLVER_NAME.CREATE, HookInNames.PRE_COMMIT, [
         documentInstance as ReturnType,
       ]);
 
       // Create the document in the database
-      const databaseDocumentInstance =
-        await this._databaseModel.create(databaseDocument);
+      const databaseDocumentInstance = await documentInstance.save();
       databaseDocument = databaseDocumentInstance.toObject({
         virtuals: true,
       }) as ReturnType;
 
-      await this.getAndRunHooks(HookInNames.POST_COMMIT, [databaseDocument]);
+      await this.getAndRunHooks(RESOLVER_NAME.CREATE, HookInNames.POST_COMMIT, [
+        databaseDocument,
+      ]);
 
       const permittedFields = await this._getPermittedFieldsForDocument(
         this.context,
@@ -124,7 +139,9 @@ export class MongoDbCreateResolver<
         permittedFields
       );
 
-      await this.getAndRunHooks(HookInNames.FINAL, [databaseDocument]);
+      await this.getAndRunHooks(RESOLVER_NAME.CREATE, HookInNames.FINAL, [
+        databaseDocument,
+      ]);
 
       return databaseDocument;
     } catch (err) {
@@ -136,6 +153,7 @@ export class MongoDbCreateResolver<
 
       // Run all the error hooks
       await this.getAndRunHooks(
+        RESOLVER_NAME.CREATE,
         HookInNames.ERROR,
         databaseDocument ? [databaseDocument] : null
       );

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbDeleteResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbDeleteResolver.ts
@@ -32,9 +32,14 @@ export class MongoDbDeleteResolver<
     let databaseDocument: ReturnType | null = null;
 
     try {
-      await this.getAndRunHooks(HookInNames.INITIAL, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
+        HookInNames.INITIAL,
+        databaseDocument
+      );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocument
       );
@@ -47,11 +52,13 @@ export class MongoDbDeleteResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
         HookInNames.POST_VALIDATE_ARGS,
         databaseDocument
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
         HookInNames.PRE_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
@@ -67,11 +74,16 @@ export class MongoDbDeleteResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
         HookInNames.POST_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
 
-      await this.getAndRunHooks(HookInNames.PRE_FETCH, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
+        HookInNames.PRE_FETCH,
+        databaseDocument
+      );
 
       // Fetch the data from the database
       const filter = { _id: this.args.id, deletedAt: null };
@@ -83,11 +95,15 @@ export class MongoDbDeleteResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_FETCH, [databaseDocument]);
-
-      await this.getAndRunHooks(HookInNames.PRE_DOCUMENT_AUTHORIZE, [
+      await this.getAndRunHooks(RESOLVER_NAME.DELETE, HookInNames.POST_FETCH, [
         databaseDocument,
       ]);
+
+      await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
+        HookInNames.PRE_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
 
       // Call the authorization service to check if client has permissions
       // for the specific document being accessed
@@ -101,11 +117,15 @@ export class MongoDbDeleteResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_DOCUMENT_AUTHORIZE, [
+      await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
+        HookInNames.POST_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
+
+      await this.getAndRunHooks(RESOLVER_NAME.DELETE, HookInNames.PRE_COMMIT, [
         databaseDocument,
       ]);
-
-      await this.getAndRunHooks(HookInNames.PRE_COMMIT, [databaseDocument]);
 
       // Delete the document from the database
       const update = { deletedAt: new Date() };
@@ -115,7 +135,9 @@ export class MongoDbDeleteResolver<
         virtuals: true,
       }) as ReturnType;
 
-      await this.getAndRunHooks(HookInNames.POST_COMMIT, [databaseDocument]);
+      await this.getAndRunHooks(RESOLVER_NAME.DELETE, HookInNames.POST_COMMIT, [
+        databaseDocument,
+      ]);
 
       const permittedFields = await this._getPermittedFieldsForDocument(
         this.context,
@@ -126,7 +148,9 @@ export class MongoDbDeleteResolver<
         permittedFields
       );
 
-      await this.getAndRunHooks(HookInNames.FINAL, [databaseDocument]);
+      await this.getAndRunHooks(RESOLVER_NAME.DELETE, HookInNames.FINAL, [
+        databaseDocument,
+      ]);
 
       return databaseDocument;
     } catch (err) {
@@ -138,6 +162,7 @@ export class MongoDbDeleteResolver<
 
       // Run all the error hooks
       await this.getAndRunHooks(
+        RESOLVER_NAME.DELETE,
         HookInNames.ERROR,
         databaseDocument ? [databaseDocument] : null
       );

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbListResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbListResolver.ts
@@ -73,19 +73,26 @@ export class MongoDbListResolver<
         this.args.filter.deletedAt = { eq: null };
       }
 
-      await this.getAndRunHooks(HookInNames.INITIAL, databaseDocuments);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
+        HookInNames.INITIAL,
+        databaseDocuments
+      );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocuments
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.POST_VALIDATE_ARGS,
         databaseDocuments
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.PRE_ARCHITECTURAL_AUTHORIZE,
         databaseDocuments
       );
@@ -101,11 +108,16 @@ export class MongoDbListResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.POST_ARCHITECTURAL_AUTHORIZE,
         databaseDocuments
       );
 
-      await this.getAndRunHooks(HookInNames.PRE_FETCH, databaseDocuments);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
+        HookInNames.PRE_FETCH,
+        databaseDocuments
+      );
 
       // Have auth converted to a filter
       const argsFilter = this.convertArgsToFilter();
@@ -134,14 +146,20 @@ export class MongoDbListResolver<
         this.getQueryOptions()
       )) as ReturnType[] | null;
 
-      await this.getAndRunHooks(HookInNames.POST_FETCH, databaseDocuments);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
+        HookInNames.POST_FETCH,
+        databaseDocuments
+      );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.PRE_DOCUMENT_AUTHORIZE,
         databaseDocuments
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
         HookInNames.POST_DOCUMENT_AUTHORIZE,
         databaseDocuments
       );
@@ -171,7 +189,7 @@ export class MongoDbListResolver<
         }) || []
       );
 
-      await this.getAndRunHooks(HookInNames.FINAL, results);
+      await this.getAndRunHooks(RESOLVER_NAME.LIST, HookInNames.FINAL, results);
 
       const returnObject = {
         results,
@@ -187,7 +205,11 @@ export class MongoDbListResolver<
       }
 
       // Run all the error hooks
-      await this.getAndRunHooks(HookInNames.ERROR, databaseDocuments);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.LIST,
+        HookInNames.ERROR,
+        databaseDocuments
+      );
 
       // If the error is not a GraphQLError, throw a generic error wrapped in a GraphQLError
       if (!(err instanceof GraphQLError)) {

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbReadResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbReadResolver.ts
@@ -37,9 +37,14 @@ export class MongoDbReadResolver<
     let databaseDocument: ReturnType | null = null;
 
     try {
-      await this.getAndRunHooks(HookInNames.INITIAL, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
+        HookInNames.INITIAL,
+        databaseDocument
+      );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocument
       );
@@ -52,11 +57,13 @@ export class MongoDbReadResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
         HookInNames.POST_VALIDATE_ARGS,
         databaseDocument
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
         HookInNames.PRE_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
@@ -72,11 +79,16 @@ export class MongoDbReadResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
         HookInNames.POST_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
 
-      await this.getAndRunHooks(HookInNames.PRE_FETCH, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
+        HookInNames.PRE_FETCH,
+        databaseDocument
+      );
 
       // Fetch the data from the database
       databaseDocument = await this._databaseModel.findById<ReturnType>(
@@ -88,11 +100,15 @@ export class MongoDbReadResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_FETCH, [databaseDocument]);
-
-      await this.getAndRunHooks(HookInNames.PRE_DOCUMENT_AUTHORIZE, [
+      await this.getAndRunHooks(RESOLVER_NAME.READ, HookInNames.POST_FETCH, [
         databaseDocument,
       ]);
+
+      await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
+        HookInNames.PRE_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
 
       // Call the authorization service to check if client has permissions
       // for the specific document being accessed
@@ -106,9 +122,11 @@ export class MongoDbReadResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_DOCUMENT_AUTHORIZE, [
-        databaseDocument,
-      ]);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
+        HookInNames.POST_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let returnDocument = (databaseDocument as any).toObject({
@@ -124,7 +142,9 @@ export class MongoDbReadResolver<
         permittedFields
       );
 
-      await this.getAndRunHooks(HookInNames.FINAL, [databaseDocument]);
+      await this.getAndRunHooks(RESOLVER_NAME.READ, HookInNames.FINAL, [
+        databaseDocument,
+      ]);
       return returnDocument;
     } catch (err) {
       if (err instanceof Error) {
@@ -135,6 +155,7 @@ export class MongoDbReadResolver<
 
       // Run all the error hooks
       await this.getAndRunHooks(
+        RESOLVER_NAME.READ,
         HookInNames.ERROR,
         databaseDocument ? [databaseDocument] : null
       );

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbUpdateResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbUpdateResolver.ts
@@ -102,6 +102,16 @@ export class MongoDbUpdateResolver<
         databaseDocument,
       ]);
 
+      // Remove the unauthorised fields from the input object
+      const permittedFieldsForInput = await this._getPermittedFieldsForDocument(
+        this.context,
+        databaseDocument
+      );
+      this.args.input = removeUnauthorisedFieldsFromDocument<ReturnType>(
+        this.args.input as ReturnType,
+        permittedFieldsForInput
+      ) as ArgType['input'];
+
       // Merge the input data with the existing data
       const updatedDocumentInstance =
         this.mergeInputWithDatabaseDocument(databaseDocument);

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbUpdateResolver.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbUpdateResolver.ts
@@ -29,9 +29,14 @@ export class MongoDbUpdateResolver<
     let databaseDocument: ReturnType | null = null;
 
     try {
-      await this.getAndRunHooks(HookInNames.INITIAL, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
+        HookInNames.INITIAL,
+        databaseDocument
+      );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
         HookInNames.PRE_VALIDATE_ARGS,
         databaseDocument
       );
@@ -44,11 +49,13 @@ export class MongoDbUpdateResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
         HookInNames.POST_VALIDATE_ARGS,
         databaseDocument
       );
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
         HookInNames.PRE_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
@@ -64,11 +71,16 @@ export class MongoDbUpdateResolver<
       }
 
       await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
         HookInNames.POST_ARCHITECTURAL_AUTHORIZE,
         databaseDocument
       );
 
-      await this.getAndRunHooks(HookInNames.PRE_FETCH, databaseDocument);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
+        HookInNames.PRE_FETCH,
+        databaseDocument
+      );
 
       // Fetch the data from the database
       const filter = { _id: this.args.input.id, deletedAt: null };
@@ -80,11 +92,15 @@ export class MongoDbUpdateResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_FETCH, [databaseDocument]);
-
-      await this.getAndRunHooks(HookInNames.PRE_DOCUMENT_AUTHORIZE, [
+      await this.getAndRunHooks(RESOLVER_NAME.UPDATE, HookInNames.POST_FETCH, [
         databaseDocument,
       ]);
+
+      await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
+        HookInNames.PRE_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
 
       // Call the authorization service to check if client has permissions
       // for the specific document being accessed
@@ -98,9 +114,11 @@ export class MongoDbUpdateResolver<
         );
       }
 
-      await this.getAndRunHooks(HookInNames.POST_DOCUMENT_AUTHORIZE, [
-        databaseDocument,
-      ]);
+      await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
+        HookInNames.POST_DOCUMENT_AUTHORIZE,
+        [databaseDocument]
+      );
 
       // Remove the unauthorised fields from the input object
       const permittedFieldsForInput = await this._getPermittedFieldsForDocument(
@@ -116,7 +134,7 @@ export class MongoDbUpdateResolver<
       const updatedDocumentInstance =
         this.mergeInputWithDatabaseDocument(databaseDocument);
 
-      await this.getAndRunHooks(HookInNames.PRE_COMMIT, [
+      await this.getAndRunHooks(RESOLVER_NAME.UPDATE, HookInNames.PRE_COMMIT, [
         updatedDocumentInstance as ReturnType,
       ]);
 
@@ -126,7 +144,7 @@ export class MongoDbUpdateResolver<
         virtuals: true,
       });
 
-      await this.getAndRunHooks(HookInNames.POST_COMMIT, [
+      await this.getAndRunHooks(RESOLVER_NAME.UPDATE, HookInNames.POST_COMMIT, [
         databaseDocument as ReturnType,
       ]);
 
@@ -139,7 +157,7 @@ export class MongoDbUpdateResolver<
         permittedFields
       );
 
-      await this.getAndRunHooks(HookInNames.FINAL, [
+      await this.getAndRunHooks(RESOLVER_NAME.UPDATE, HookInNames.FINAL, [
         databaseDocument as ReturnType,
       ]);
 
@@ -153,6 +171,7 @@ export class MongoDbUpdateResolver<
 
       // Run all the error hooks
       await this.getAndRunHooks(
+        RESOLVER_NAME.UPDATE,
         HookInNames.ERROR,
         databaseDocument ? [databaseDocument] : null
       );

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/tests/MongoDbCreateResolver.data.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/tests/MongoDbCreateResolver.data.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { cloneDeep } from 'lodash';
+import { type MongoDbCreateResolverParams } from '../MongoDbCreateResolver';
+
+const USER_MODEL_FIELDS = [
+  'id',
+  'firstName',
+  'lastName',
+  'email',
+  'testField',
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+] as const;
+
+export const DEFAULT_VALUES = {
+  USER_MODEL_FIELDS,
+  TEST_MODEL_NAME: 'User',
+} as const;
+
+const standardUser = {
+  id: '123',
+  firstName: 'firstNameTest',
+  lastName: 'lastNameTest',
+  email: 'emailTest',
+  createdAt: new Date('2024-06-01T12:00:00.000Z'),
+  updatedAt: new Date('2024-06-01T12:00:00.000Z'),
+  deletedAt: null,
+};
+
+export function getStandardUser() {
+  return cloneDeep(standardUser);
+}
+
+export function getStandardUserDatabaseObject() {
+  return {
+    ...getStandardUser(),
+    toObject: jest.fn().mockReturnValue(getStandardUser()),
+  };
+}
+
+export function getStandardUserInput() {
+  const standardUserInput = {
+    firstName: standardUser.firstName,
+    lastName: standardUser.lastName,
+    email: standardUser.email,
+  };
+  return cloneDeep(standardUserInput);
+}
+
+const databaseModelImplementationSave = jest
+  .fn()
+  .mockResolvedValue(getStandardUserDatabaseObject());
+
+const databaseModelImplementationValidate = jest.fn();
+
+const databaseModelImplementation = jest.fn().mockImplementation(() => {
+  return {
+    validate: databaseModelImplementationValidate,
+    save: databaseModelImplementationSave,
+  };
+}) as any;
+
+export function getDatabaseModelImplementation() {
+  return databaseModelImplementation;
+}
+
+export function getDatabaseModelImplementationSave() {
+  return databaseModelImplementationSave;
+}
+
+export function getDatabaseModelImplementationValidate() {
+  return databaseModelImplementationValidate;
+}
+
+const initialisationParams: MongoDbCreateResolverParams<any, any> = {
+  context: {
+    autographcraft: {
+      authorisationInstance: {
+        initialise: jest.fn(),
+        initialiseWithCachedData: jest.fn(),
+        getCacheableData: jest.fn(),
+        hasAuthIdsForModel: jest.fn().mockReturnValue(true),
+        documentAuthorisation: jest.fn().mockReturnValue(true),
+        getAuthIdsForModel: jest.fn().mockReturnValue([]),
+      },
+    },
+  },
+  args: { input: getStandardUserInput() },
+  modelName: DEFAULT_VALUES.TEST_MODEL_NAME,
+  databaseModel: databaseModelImplementation,
+  hookInFiles: [],
+  parent: undefined,
+  info: undefined,
+  architecturalAuthorisation: jest.fn().mockReturnValue(true),
+  documentAuthorisation: jest.fn().mockReturnValue(true),
+  getPermittedFieldsForDocument: jest
+    .fn()
+    .mockReturnValue(new Set(DEFAULT_VALUES.USER_MODEL_FIELDS)),
+};
+
+initialisationParams.databaseModel.create = jest.fn().mockResolvedValue({
+  toObject: jest.fn().mockReturnValue(getStandardUser()),
+});
+
+export function getInitialisationParams() {
+  const clonedInitialisationParams = cloneDeep(initialisationParams);
+  clonedInitialisationParams.databaseModel = databaseModelImplementation;
+  return clonedInitialisationParams;
+}

--- a/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/tests/MongoDbCreateResolver.spec.ts
+++ b/packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/tests/MongoDbCreateResolver.spec.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { HookInNames, RESOLVER_NAME } from '@autographcraft/core';
+import { MongoDbCreateResolver } from '../MongoDbCreateResolver';
+import {
+  getDatabaseModelImplementationSave,
+  getDatabaseModelImplementationValidate,
+  getInitialisationParams,
+  getStandardUser,
+  getStandardUserInput,
+} from './MongoDbCreateResolver.data';
+
+describe('MongoDbCreateResolver', () => {
+  it('should be defined', () => {
+    expect(MongoDbCreateResolver).toBeDefined();
+  });
+
+  it('should create a new document without any hooks or auth failures', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    const databaseModelImplementationSave =
+      getDatabaseModelImplementationSave();
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    const result = await resolver.create();
+
+    // Assert
+    expect(initialisationParams.databaseModel).toHaveBeenCalledTimes(1);
+    expect(initialisationParams.databaseModel).toHaveBeenCalledWith(
+      getStandardUserInput()
+    );
+    expect(initialisationParams.databaseModel.create).toHaveBeenCalledTimes(0);
+    expect(databaseModelImplementationSave).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(getStandardUser());
+  });
+
+  it('should throw an error if the user does not have permission to create a document', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    initialisationParams.documentAuthorisation = jest
+      .fn()
+      .mockReturnValue(false);
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    const action = async () => await resolver.create();
+
+    // Assert
+    await expect(action).rejects.toThrow(
+      `Caller does not have permission to create a document with the provided input`
+    );
+  });
+
+  it('should throw an error if the document validation fails', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    const databaseModelImplementationValidate =
+      getDatabaseModelImplementationValidate();
+    databaseModelImplementationValidate.mockRejectedValueOnce(
+      new Error('Test error')
+    );
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    const action = async () => await resolver.create();
+
+    // Assert
+    await expect(action).rejects.toThrow('Test error');
+  });
+
+  it('should call the appropriate hooks', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    const preValidateHook = jest.fn();
+    const postValidateHook = jest.fn();
+
+    initialisationParams.hookInFiles = [
+      {
+        hookPoint: HookInNames.PRE_VALIDATE_DOCUMENT,
+        defaultFunction: preValidateHook,
+        filename: 'testFileHook',
+        resolverName: RESOLVER_NAME.CREATE,
+        orderNumber: 1,
+      },
+    ];
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    await resolver.create();
+
+    // Assert
+    expect(preValidateHook).toHaveBeenCalledTimes(1);
+    expect(postValidateHook).toHaveBeenCalledTimes(0);
+  });
+
+  it('should have data added in a hook persist through to the final document', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    const initialHook = jest.fn().mockImplementation((_parent, args) => {
+      args.input.testField = 'test';
+    });
+    const preValidateHook = jest.fn().mockImplementation();
+
+    initialisationParams.hookInFiles = [
+      {
+        hookPoint: HookInNames.INITIAL,
+        defaultFunction: initialHook,
+        filename: 'testFileHook',
+        resolverName: RESOLVER_NAME.CREATE,
+        orderNumber: 1,
+      },
+      {
+        hookPoint: HookInNames.PRE_VALIDATE_ARGS,
+        defaultFunction: preValidateHook,
+        filename: 'testFileHook',
+        resolverName: RESOLVER_NAME.CREATE,
+        orderNumber: 1,
+      },
+    ];
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    await resolver.create();
+
+    // Assert
+    expect(initialHook).toHaveBeenCalledTimes(1);
+    expect(preValidateHook).toHaveBeenCalledTimes(1);
+    expect(initialHook).toHaveBeenCalledWith(
+      initialisationParams.parent,
+      initialisationParams.args,
+      initialisationParams.context,
+      initialisationParams.info,
+      null
+    );
+    expect(preValidateHook).toHaveBeenCalledWith(
+      initialisationParams.parent,
+      { input: { ...getStandardUserInput(), testField: 'test' } },
+      initialisationParams.context,
+      initialisationParams.info,
+      null
+    );
+  });
+
+  it('should have data in the args that is not permitted removed after the initial hook', async () => {
+    // Arrange
+    const initialisationParams = getInitialisationParams();
+    const initialHook = jest.fn().mockImplementation();
+    const preValidateHook = jest.fn().mockImplementation();
+
+    initialisationParams.hookInFiles = [
+      {
+        hookPoint: HookInNames.INITIAL,
+        defaultFunction: initialHook,
+        filename: 'testFileHook',
+        resolverName: RESOLVER_NAME.CREATE,
+        orderNumber: 1,
+      },
+      {
+        hookPoint: HookInNames.PRE_VALIDATE_ARGS,
+        defaultFunction: preValidateHook,
+        filename: 'testFileHook',
+        resolverName: RESOLVER_NAME.CREATE,
+        orderNumber: 1,
+      },
+    ];
+
+    initialisationParams.args.input = {
+      ...getStandardUserInput(),
+      notAllowedField: 'notAllowedField',
+    };
+
+    // Act
+    const resolver = new MongoDbCreateResolver(initialisationParams);
+    await resolver.create();
+
+    // Assert
+    expect(initialHook).toHaveBeenCalledTimes(1);
+    expect(preValidateHook).toHaveBeenCalledTimes(1);
+    expect(initialHook).toHaveBeenCalledWith(
+      initialisationParams.parent,
+      initialisationParams.args,
+      initialisationParams.context,
+      initialisationParams.info,
+      null
+    );
+    expect(preValidateHook).toHaveBeenCalledWith(
+      initialisationParams.parent,
+      { input: getStandardUserInput() },
+      initialisationParams.context,
+      initialisationParams.info,
+      null
+    );
+  });
+});


### PR DESCRIPTION
This pull request includes several updates to the documentation and codebase, focusing on improving the `@fieldAuth` and `@modelAuth` directives and enhancing the MongoDB resolvers. Key changes include adding new sections to the documentation, updating example configurations, and refining resolver hooks.

### Documentation Updates:
* [`README-DIRECTIVE-FIELD-AUTH.md`](diffhunk://#diff-a261d1158461316b541645de756f1469ceb0b30317904467e54f9a1ccb00c298R5-R6): Added a detailed explanation of the `@fieldAuth` directive and its precedence over the `@modelAuth` directive. Included examples to clarify the usage. [[1]](diffhunk://#diff-a261d1158461316b541645de756f1469ceb0b30317904467e54f9a1ccb00c298R5-R6) [[2]](diffhunk://#diff-a261d1158461316b541645de756f1469ceb0b30317904467e54f9a1ccb00c298L60-R116)
* [`README-DIRECTIVE-MODEL-AUTH.md`](diffhunk://#diff-ed3912b69615dd676778dc1f39edacb7507cd414df71715456e6c6a86eb62a72R3-R8): Added a table of contents and a new section on special authorising models, including `public`, `signedIn`, and `admin`. [[1]](diffhunk://#diff-ed3912b69615dd676778dc1f39edacb7507cd414df71715456e6c6a86eb62a72R3-R8) [[2]](diffhunk://#diff-ed3912b69615dd676778dc1f39edacb7507cd414df71715456e6c6a86eb62a72R128-R156)

### Codebase Enhancements:
* [`examples/yogaServerWithMongoDb/index.ts`](diffhunk://#diff-3609eb3e5bb310af664b7cb4c1105715225417a601aa9b1ff37f6e1bcc17c912L32-R32): Updated the `authInitialisationData` to use a new user ID.
* [`packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbBaseResolver.ts`](diffhunk://#diff-93f201d4573193514b45bd5c494878faa18838154054ad400aae27346cdc287aR82-R86): Modified the `getAndRunHooks` method to accept a `resolverName` parameter, improving hook management.

### MongoDB Resolvers Refinement:
* [`packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbCreateResolver.ts`](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190L25-R56): Enhanced the `MongoDbCreateResolver` to run hooks with the `RESOLVER_NAME.CREATE` parameter and added logic to remove unauthorized fields from the input object. [[1]](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190L25-R56) [[2]](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190R72-R78) [[3]](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190R96-R131) [[4]](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190L117-R144) [[5]](diffhunk://#diff-35556ebf7ce58738e96a0f5b20e7641d47e1691649d262c65c2777c1fb136190R156)
* [`packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbDeleteResolver.ts`](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL35-R42): Updated the `MongoDbDeleteResolver` to run hooks with the `RESOLVER_NAME.DELETE` parameter, ensuring consistent hook execution. [[1]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL35-R42) [[2]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcR55-R61) [[3]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcR77-R86) [[4]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL86-R107) [[5]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL104-L109) [[6]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL118-R140) [[7]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcL129-R153) [[8]](diffhunk://#diff-c51c5e6b8e817fc2a4330f6c32f5a6fe38de4550d9a17432727620c6e29a0dbcR165)
* [`packages/mongodb/src/resolverClasses/mongoDbWithApolloServer/MongoDbListResolver.ts`](diffhunk://#diff-14b07b1bcabde284a174c6fd57cddcf306d2987d2cb9909d4325f1eea9519865L76-R95): Adjusted the `MongoDbListResolver` to run hooks with the `RESOLVER_NAME.LIST` parameter, improving list operations. [[1]](diffhunk://#diff-14b07b1bcabde284a174c6fd57cddcf306d2987d2cb9909d4325f1eea9519865L76-R95) [[2]](diffhunk://#diff-14b07b1bcabde284a174c6fd57cddcf306d2987d2cb9909d4325f1eea9519865R111-R120)