### PR TITLE
Added documentation

### DIFF
--- a/README-DIRECTIVE-FIELD-AUTH.md
+++ b/README-DIRECTIVE-FIELD-AUTH.md
@@ -63,6 +63,9 @@ On the specified model `User` there is a field called `userOnlyReadField`.  This
 
 The `@fieldAuth` directive specifies that only the `User` this model represents can read the `userOnlyReadField` field.  All other callers will receive `null` when querying this field.  Because this field is only readable by the `User` represented by the document, the field must be nullable so that the `null` value can be returned to other callers.
 
+> **&#9432; NOTE:**  
+> The `@fieldAuth` directive cannot be used on the `id` field of a model.  This is because the `id` field is mandatory and there must always be returned if any other field is returned from the requested database entry.
+
 Adding the `@fieldAuth` directive to a field will not affect the visibility of the field in the GraphQL schema.  The field will still be visible to all callers on the GraphQL introspection query, but only the authorised callers will be able to read or write to the field.
 
 Adding the `fieldAuth` directive to a field will remove the functionality of the `@modelAuth` directives on the type.  The `@fieldAuth` directive will take precedence over the `@modelAuth` directive.  This means that if a field has a `@fieldAuth` directive, the `@modelAuth` directives will be ignored for that field and any methods specified in the `@modelAuth` directive will not be available to the caller unless they are also specified in a `@fieldAuth` directive for the field.  For example:

--- a/README-DIRECTIVE-MODEL.md
+++ b/README-DIRECTIVE-MODEL.md
@@ -2,6 +2,11 @@
 
 The `@model` directive is used to specify that the type should be used to generate resolvers.
 
+- [`@model` Directive Documentation](#model-directive-documentation)
+  - [Directive Specification](#directive-specification)
+  - [Usage](#usage)
+  - [Generation Output](#generation-output)
+
 ## Directive Specification
 
 The full directive is specified as:
@@ -35,6 +40,8 @@ type User @model {
 
 In the example above, the `User` type is specified as a model.  This means that the `User` type will be used to generate resolvers.
 
+The `@model` directive must include the `id: ID!` field.  This field is used to uniquely identify the document in the database and to connect documents together.  If this field is not included, the generation process will fail.
+
 By default, the following resolvers will be generated for the `User` type:
 
 - `createUser` - Create a new user
@@ -54,3 +61,39 @@ type User @model(mutations: { create: false, delete: false }) {
 ```
 
 The values that are not specified in the `queries` or `mutations` arguements will default to `true`.
+
+## Generation Output
+
+The `@model` directive will add three (3) timestamp fields to the type:
+
+- `createdAt: ISO8601DateTime!` - The date and time the document was created
+- `updatedAt: ISO8601DateTime!` - The date and time the document was last updated
+- `deletedAt: ISO8601DateTime` - The date and time the document was deleted
+
+These fields are not editable via the API and are automatically set by the system.  The fields will return the timestamp of the event is ISO8601 datetime format at UTC (e.g. `2024-03-02T01:23:45.678Z`)
+
+The `deletedAt` field is only set when a document is deleted and is used to mark the document as deleted without actually removing it from the database.  Using this soft-delete method allows for the document to be restored if needed.  
+
+> **&#9432; NOTE:**  
+> Database entries with a populated value for `deletedAt` are automatically filtered out from `list` queries.  If you want to include deleted database entries in the API response, include a `filter` in the request to get the results you want:
+
+```json
+{
+  "filter": {
+    "or": [
+      // return non-deleted records
+      {
+        "deletedAt": {
+          "exists": false
+        }
+      },
+      // return deleted records
+      {
+        "deletedAt": {
+          "exists": true
+        }
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
- Added note that `@fieldAuth` cannot be used on the `id` field
- Added information regarding the generated timestamp fields for `@model`