### PR TITLE
Task/delete removed models

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ The initialisation is a guided process to create the configuration which can be 
 npx autographcraft init
 ```
 
-If you wish to initialise with the default settings, use:
+If you wish to initialise with the default settings, use the `--default` flag:
 
 ```sh
 npx autographcraft init --default
+
+# OR
+
+npx autographcraft init -d
 ```
 
 ### Running the Package
@@ -94,14 +98,18 @@ The generation process will only request the generation of the files if the sche
 
 ```sh
 npx autographcraft generate --force
+
+# OR
+
+npx autographcraft generate -f
 ```
 
-If you wish to turn off the logging output when running the `generate` command, add the `--quiet` or `-q` flag to the end of the command.
+If you wish to turn off the logging output when running the `generate` command, add the `--quiet` flag to the end of the command.
 
 ```sh
 npx autographcraft generate --quiet
 
-# or
+# OR
 
 npx autographcraft generate -q
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ npx autographcraft generate --quiet
 npx autographcraft generate -q
 ```
 
+If you remove a model from the schema, you may also wish to remove the generated files from your project.  This can be done by running the `--clean-models` flag:
+
+```sh
+npx autographcraft generate --clean-models
+
+# OR
+
+npx autographcraft generate -cm
+```
+
+> **NOTE:**  
+> The `--clean-models` flag will remove the entire model directory, including any committed files in the `hookIns` directory.
+
 If you need help at any time, run the command `npx autographcraft help` to open the full documentation.
 
 ### Implement the Package

--- a/package-lock.json
+++ b/package-lock.json
@@ -10275,7 +10275,7 @@
     },
     "packages/core": {
       "name": "@autographcraft/core",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "^5.0.3",
@@ -10320,10 +10320,10 @@
     },
     "packages/generate": {
       "name": "@autographcraft/generate",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@autographcraft/core": "^1.2.0",
+        "@autographcraft/core": "^1.3.0",
         "@graphql-codegen/cli": "^5.0.3",
         "@graphql-codegen/plugin-helpers": "^5.1.0",
         "@graphql-codegen/typescript": "4.1.1",
@@ -10358,10 +10358,10 @@
     },
     "packages/mongodb": {
       "name": "@autographcraft/mongodb",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@autographcraft/core": "^1.2.0",
+        "@autographcraft/core": "^1.3.0",
         "graphql": "^15.5.0",
         "lodash.clonedeep": "^4.5.0",
         "mongoose": "^8.8.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autographcraft/core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The core application for AutoGraphCraft",
   "main": "./dist/commonjs/app.js",
   "module": "./dist/esm/app.js",

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autographcraft/generate",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The generate application for AutoGraphCraft",
   "bin": {
     "autographcraft": "dist/esm/app.js"

--- a/packages/generate/src/app.ts
+++ b/packages/generate/src/app.ts
@@ -5,7 +5,7 @@ import { init } from './processFunctions/init';
 import { config } from './processFunctions/config';
 import { help } from './processFunctions/help';
 import { generateAndSave } from './processFunctions/generateAndSave';
-import { PROCESS_ARGUMENT_VECTORS } from './constants';
+import { PROCESS_ARGUMENT_PARAMS, PROCESS_ARGUMENT_VECTORS } from './constants';
 import type { ProcessFunction } from './types';
 
 // FUTURE: Allow the user to force a new login via a flag (for account changing)
@@ -36,7 +36,10 @@ export async function main() {
       }
 
       // If the params include the quiet flag, set the logger to quiet
-      if (params.includes('--quiet') || params.includes('-q')) {
+      if (
+        params.includes(PROCESS_ARGUMENT_PARAMS.QUIET) ||
+        params.includes(PROCESS_ARGUMENT_PARAMS.QUIET_SHORT)
+      ) {
         logger.silent = true;
       }
 

--- a/packages/generate/src/constants/index.ts
+++ b/packages/generate/src/constants/index.ts
@@ -33,3 +33,16 @@ export const PROCESS_ARGUMENT_VECTORS: ProcessArgumentVector[] = [
     code: PROCESS_ARGUMENT_VECTOR_CODES.GENERATE,
   },
 ] as const;
+
+export const PROCESS_ARGUMENT_PARAMS = {
+  FORCE: '--force',
+  FORCE_SHORT: '-f',
+  DEFAULT: '--default',
+  DEFAULT_SHORT: '-d',
+  DRY_RUN: '--dry-run',
+  DRY_RUN_SHORT: '-dr',
+  CLEAN_MODELS: '--clean-models',
+  CLEAN_MODELS_SHORT: '-cm',
+  QUIET: '--quiet',
+  QUIET_SHORT: '-q',
+} as const;

--- a/packages/generate/src/processFunctions/generateAndSave.ts
+++ b/packages/generate/src/processFunctions/generateAndSave.ts
@@ -110,12 +110,6 @@ export async function generateAndSave(
     });
   }
 
-  // TODO: Tidy up the generated database folder
-
-  // TODO: Tidy up the generated schema folder
-
-  // TODO: Tidy up the generated database document types folder
-
   // If the param to delete existing models is present, delete the existing models
   const shouldCleanModels =
     params.includes(PROCESS_ARGUMENT_PARAMS.CLEAN_MODELS) ||

--- a/packages/generate/src/processFunctions/generateAndSave.ts
+++ b/packages/generate/src/processFunctions/generateAndSave.ts
@@ -18,13 +18,16 @@ import {
   getAutoGraphCraftApiResponse,
   writeFilesToFileSystem,
 } from '../processFunctions';
+import { PROCESS_ARGUMENT_PARAMS } from '../constants';
 
 export async function generateAndSave(
   currentWorkingDirectory: string,
   params: string[]
 ): Promise<void> {
   // Check if the request is a dry run
-  const isDryRun = params.includes('--dry-run');
+  const isDryRun =
+    params.includes(PROCESS_ARGUMENT_PARAMS.DRY_RUN) ||
+    params.includes(PROCESS_ARGUMENT_PARAMS.DRY_RUN_SHORT);
   if (isDryRun) {
     logger.info('ℹ️ Dry run requested, no files will be written');
   }
@@ -63,7 +66,7 @@ export async function generateAndSave(
   );
   if (isSameAsPreviousRequest) {
     logger.info(
-      'ℹ️ No changes detected, no files will be written. Use `--force` to force a new generation'
+      `ℹ️ No changes detected, no files will be written. Use '${PROCESS_ARGUMENT_PARAMS.FORCE}' or '${PROCESS_ARGUMENT_PARAMS.FORCE_SHORT}' to force a new generation`
     );
     return;
   }
@@ -105,6 +108,14 @@ export async function generateAndSave(
       logger.warn(`⚠️ Warning: ${warning}`);
     });
   }
+
+  // TODO: Tidy up the generated database folder
+
+  // TODO: Tidy up the generated schema folder
+
+  // TODO: Tidy up the generated database document types folder
+
+  // TODO: If the param to delete existing models is present, delete the existing models
 
   // Give user some statistics
   const printStatisticsParams: PrintStatisticsParams = {

--- a/packages/generate/src/processFunctions/generateAndSave.ts
+++ b/packages/generate/src/processFunctions/generateAndSave.ts
@@ -13,11 +13,12 @@ import {
   type PrintStatisticsParams,
 } from './helpers';
 import {
-  fetchMergedTypeDefs,
   getAuthIdToken,
-  getAutoGraphCraftApiResponse,
+  cleanModels,
   writeFilesToFileSystem,
-} from '../processFunctions';
+  getAutoGraphCraftApiResponse,
+  fetchMergedTypeDefs,
+} from './generateFunctions';
 import { PROCESS_ARGUMENT_PARAMS } from '../constants';
 
 export async function generateAndSave(
@@ -115,7 +116,14 @@ export async function generateAndSave(
 
   // TODO: Tidy up the generated database document types folder
 
-  // TODO: If the param to delete existing models is present, delete the existing models
+  // If the param to delete existing models is present, delete the existing models
+  const shouldCleanModels =
+    params.includes(PROCESS_ARGUMENT_PARAMS.CLEAN_MODELS) ||
+    params.includes(PROCESS_ARGUMENT_PARAMS.CLEAN_MODELS_SHORT);
+
+  if (shouldCleanModels) {
+    cleanModels(currentWorkingDirectory, existingConfig, allFiles);
+  }
 
   // Give user some statistics
   const printStatisticsParams: PrintStatisticsParams = {

--- a/packages/generate/src/processFunctions/generateFunctions/cleanModels.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/cleanModels.ts
@@ -1,0 +1,76 @@
+import { logger } from '@autographcraft/core';
+import { readdirSync, rmSync } from 'node:fs';
+import { join } from 'path';
+import type {
+  AutoGraphCraftConfiguration,
+  OutputFileDetail,
+} from '@autographcraft/core';
+
+export function cleanModels(
+  currentWorkingDirectory: string,
+  config: AutoGraphCraftConfiguration,
+  allFiles: OutputFileDetail[]
+): void {
+  logger.info(
+    'ℹ️ Deleting existing model directories where the model was not found in the latest schema...'
+  );
+
+  // Read all the model directories in the generatedModelsDirectory from the configuration
+  const generatedModelsDirectory = join(
+    currentWorkingDirectory,
+    config.generatedModelsDirectory
+  );
+
+  // Get all the model directories
+  const modelDirectories = readdirSync(generatedModelsDirectory, {
+    withFileTypes: true,
+  })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+  // Get all the model names from the generated files
+  const modelNames = getAllModelNamesFromFiles(
+    allFiles,
+    config.generatedModelsDirectory
+  );
+
+  // For each model directory, check if the model is in the latest schema
+  // If not, delete the directory
+  modelDirectories.forEach((modelDirectory) => {
+    if (!modelNames.includes(modelDirectory)) {
+      logger.info(`Deleting model directory: ${modelDirectory}`);
+      // Remove the model directory
+      rmSync(join(generatedModelsDirectory, modelDirectory), {
+        recursive: true,
+        force: true,
+      });
+    }
+  });
+}
+
+/**
+ * Returns all the unique model names from the generated files
+ * @param allFiles The generated files
+ * @param generatedModelsDirectory The generated models directory
+ * @returns
+ */
+function getAllModelNamesFromFiles(
+  allFiles: OutputFileDetail[],
+  generatedModelsDirectory: string
+): string[] {
+  const modelDirectoryFiles = allFiles.filter((generatedFile) => {
+    return generatedFile.filePath.startsWith(generatedModelsDirectory);
+  });
+
+  const modelNamesFromAllFiles: string[] = modelDirectoryFiles.map(
+    (generatedFile) => {
+      const removedGeneratedModelsDirectory = generatedFile.filePath.replace(
+        `${generatedModelsDirectory}/`,
+        ''
+      );
+      return removedGeneratedModelsDirectory.split('/')[0];
+    }
+  );
+
+  return Array.from(new Set(modelNamesFromAllFiles));
+}

--- a/packages/generate/src/processFunctions/generateFunctions/cleanModels.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/cleanModels.ts
@@ -15,13 +15,32 @@ export function cleanModels(
     'ℹ️ Deleting existing model directories where the model was not found in the latest schema...'
   );
 
-  // Read all the model directories in the generatedModelsDirectory from the configuration
   const generatedModelsDirectory = join(
     currentWorkingDirectory,
     config.generatedModelsDirectory
   );
 
-  // Get all the model directories
+  const generatedDatabaseDirectory = join(
+    currentWorkingDirectory,
+    config.generatedDatabaseDirectory
+  );
+
+  const generatedDatabaseConnectionsDirectory = join(
+    generatedDatabaseDirectory,
+    'databaseConnections'
+  );
+
+  const generatedDocumentTypesDirectory = join(
+    generatedDatabaseDirectory,
+    'databaseDocumentTypes'
+  );
+
+  const generatedSchemaDirectory = join(
+    generatedDatabaseDirectory,
+    'databaseSchemas'
+  );
+
+  // Read all the model directories in the generatedModelsDirectory
   const modelDirectories = readdirSync(generatedModelsDirectory, {
     withFileTypes: true,
   })
@@ -38,9 +57,45 @@ export function cleanModels(
   // If not, delete the directory
   modelDirectories.forEach((modelDirectory) => {
     if (!modelNames.includes(modelDirectory)) {
+      const modelNameOnly = modelDirectory.replace('model', '');
+
       logger.info(`Deleting model directory: ${modelDirectory}`);
+
       // Remove the model directory
       rmSync(join(generatedModelsDirectory, modelDirectory), {
+        recursive: true,
+        force: true,
+      });
+
+      // Tidy up the database connections directory
+      const databaseConnectionFileName = `${modelNameOnly}DatabaseConnection.ts`;
+      const databaseConnectionFile = join(
+        generatedDatabaseConnectionsDirectory,
+        databaseConnectionFileName
+      );
+      rmSync(databaseConnectionFile, {
+        recursive: true,
+        force: true,
+      });
+
+      // Tidy up the generated database document types directory
+      const databaseDocumentTypeFileName = `${modelNameOnly}DatabaseDocumentType.ts`;
+      const databaseDocumentTypeFile = join(
+        generatedDocumentTypesDirectory,
+        databaseDocumentTypeFileName
+      );
+      rmSync(databaseDocumentTypeFile, {
+        recursive: true,
+        force: true,
+      });
+
+      // Tidy up the generated schema directory
+      const databaseSchemaFileName = `${modelNameOnly}DatabaseSchema.ts`;
+      const databaseSchemaFile = join(
+        generatedSchemaDirectory,
+        databaseSchemaFileName
+      );
+      rmSync(databaseSchemaFile, {
         recursive: true,
         force: true,
       });

--- a/packages/generate/src/processFunctions/generateFunctions/fetchMergedTypeDefs.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/fetchMergedTypeDefs.ts
@@ -13,7 +13,7 @@ import { DEFAULT_SCALARS, PACKAGE_SCALARS } from '@autographcraft/core';
 import {
   convertSchemaToDocumentTypeDef,
   convertScalarDetailToScalarFilterInput,
-} from './helpers';
+} from '../helpers';
 
 const PERMITTED_EXTENSIONS: string[] = ['graphql', 'gql'];
 

--- a/packages/generate/src/processFunctions/generateFunctions/getAuthIdToken.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/getAuthIdToken.ts
@@ -6,10 +6,10 @@ import {
   getExistingAuthTokens,
   writeAuthTokens,
   startRedirectServer,
-} from '../helpers';
+} from '../../helpers';
 import { logger } from '@autographcraft/core';
-import { SIGN_IN_URL } from '../constants';
-import type { AuthTokens } from '../types';
+import { SIGN_IN_URL } from '../../constants';
+import type { AuthTokens } from '../../types';
 
 /**
  * Fetches the auth token for the user, or prompts the user to visit the

--- a/packages/generate/src/processFunctions/generateFunctions/getAutoGraphCraftApiResponse.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/getAutoGraphCraftApiResponse.ts
@@ -1,8 +1,8 @@
-import { AUTOGRAPHCRAFT_API_URL } from '../constants';
-import type { AutoGraphCraftApiResponse } from '../types';
+import { AUTOGRAPHCRAFT_API_URL } from '../../constants';
+import type { AutoGraphCraftApiResponse } from '../../types';
 import { logger } from '@autographcraft/core';
 import type { AutoGraphCraftConfiguration } from '@autographcraft/core';
-import { getFileGenerationQuery } from './helpers';
+import { getFileGenerationQuery } from '../helpers';
 
 type APIError = {
   message: string;

--- a/packages/generate/src/processFunctions/generateFunctions/index.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/index.ts
@@ -1,0 +1,5 @@
+export { cleanModels } from './cleanModels';
+export { writeFilesToFileSystem } from './writeFilesToFileSystem';
+export { getAutoGraphCraftApiResponse } from './getAutoGraphCraftApiResponse';
+export { fetchMergedTypeDefs } from './fetchMergedTypeDefs';
+export { getAuthIdToken } from './getAuthIdToken';

--- a/packages/generate/src/processFunctions/generateFunctions/tests/cleanModels.spec.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/tests/cleanModels.spec.ts
@@ -23,6 +23,8 @@ describe('cleanModels', () => {
   it('should delete model directories that are not found in the latest schema', () => {
     const config = {
       generatedModelsDirectory: 'generatedModelsDirectory',
+      generatedTypesDirectory: 'generatedTypesDirectory',
+      generatedDatabaseDirectory: 'generatedDatabaseDirectory',
     } as any;
     const allFiles = [
       {
@@ -52,9 +54,34 @@ describe('cleanModels', () => {
       { withFileTypes: true }
     );
 
-    expect(rmSync).toHaveBeenCalledTimes(1);
-    expect(rmSync).toHaveBeenCalledWith(
+    expect(rmSync).toHaveBeenCalledTimes(4);
+    expect(rmSync).toHaveBeenNthCalledWith(
+      1,
       '/current/working/directory/generatedModelsDirectory/modelCompany',
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(rmSync).toHaveBeenNthCalledWith(
+      2,
+      '/current/working/directory/generatedDatabaseDirectory/databaseConnections/CompanyDatabaseConnection.ts',
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(rmSync).toHaveBeenNthCalledWith(
+      3,
+      '/current/working/directory/generatedDatabaseDirectory/databaseDocumentTypes/CompanyDatabaseDocumentType.ts',
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(rmSync).toHaveBeenNthCalledWith(
+      4,
+      '/current/working/directory/generatedDatabaseDirectory/databaseSchemas/CompanyDatabaseSchema.ts',
       {
         force: true,
         recursive: true,

--- a/packages/generate/src/processFunctions/generateFunctions/tests/cleanModels.spec.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/tests/cleanModels.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { readdirSync, rmSync } from 'node:fs';
+import { cleanModels } from '../cleanModels';
+
+jest.mock('@autographcraft/core', () => ({
+  logger: {
+    info: jest.fn(),
+  },
+}));
+
+jest.mock('node:fs', () => ({
+  readdirSync: jest.fn(),
+  rmSync: jest.fn(),
+}));
+
+const CWD = '/current/working/directory';
+
+describe('cleanModels', () => {
+  it('should be defined', () => {
+    expect(cleanModels).toBeDefined();
+  });
+
+  it('should delete model directories that are not found in the latest schema', () => {
+    const config = {
+      generatedModelsDirectory: 'generatedModelsDirectory',
+    } as any;
+    const allFiles = [
+      {
+        filePath: 'generatedModelsDirectory/modelUser/resolvers/readUser.ts',
+      },
+      {
+        filePath:
+          'generatedModelsDirectory/modelEmployee/resolvers/readEmployee.ts',
+      },
+      {
+        filePath:
+          'generatedTypesDirectory/modelEmployee/resolvers/readEmployee.ts',
+      },
+    ] as any;
+
+    (readdirSync as jest.Mock).mockReturnValueOnce([
+      { isDirectory: () => true, name: 'modelUser' },
+      { isDirectory: () => true, name: 'modelEmployee' },
+      { isDirectory: () => true, name: 'modelCompany' },
+      { isDirectory: () => false, name: 'somefile.ts' },
+    ]);
+
+    cleanModels(CWD, config, allFiles);
+
+    expect(readdirSync).toHaveBeenCalledWith(
+      '/current/working/directory/generatedModelsDirectory',
+      { withFileTypes: true }
+    );
+
+    expect(rmSync).toHaveBeenCalledTimes(1);
+    expect(rmSync).toHaveBeenCalledWith(
+      '/current/working/directory/generatedModelsDirectory/modelCompany',
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+  });
+});

--- a/packages/generate/src/processFunctions/generateFunctions/writeFilesToFileSystem.ts
+++ b/packages/generate/src/processFunctions/generateFunctions/writeFilesToFileSystem.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'path';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import type { OutputFileDetail } from '@autographcraft/core';
-import { addIgnoreHeaderToContent } from './helpers';
+import { addIgnoreHeaderToContent } from '../helpers';
 import { logger } from '@autographcraft/core';
 
 export function writeFilesToFileSystem(

--- a/packages/generate/src/processFunctions/helpers/checkIfSameAsPreviousRequest.ts
+++ b/packages/generate/src/processFunctions/helpers/checkIfSameAsPreviousRequest.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import {
   STORED_DETAILS_DIR_NAME,
   LAST_REQUEST_FILE_NAME,
+  PROCESS_ARGUMENT_PARAMS,
 } from '../../constants';
 import type {
   AutoGraphCraftConfiguration,
@@ -25,7 +26,11 @@ export function checkIfSameAsPreviousRequest(
   currentConfiguration: AutoGraphCraftConfiguration,
   schema: MergedTypeDef
 ): boolean {
-  if (params.includes('--force')) {
+  if (params.includes(PROCESS_ARGUMENT_PARAMS.FORCE)) {
+    return false;
+  }
+
+  if (params.includes(PROCESS_ARGUMENT_PARAMS.FORCE_SHORT)) {
     return false;
   }
 

--- a/packages/generate/src/processFunctions/index.ts
+++ b/packages/generate/src/processFunctions/index.ts
@@ -1,7 +1,3 @@
-export { fetchMergedTypeDefs } from './fetchMergedTypeDefs';
-export { getAuthIdToken } from './getAuthIdToken';
-export { getAutoGraphCraftApiResponse } from './getAutoGraphCraftApiResponse';
-export { writeFilesToFileSystem } from './writeFilesToFileSystem';
 export { generateAndSave } from './generateAndSave';
 export { init } from './init';
 export { config } from './config';

--- a/packages/generate/src/processFunctions/init.ts
+++ b/packages/generate/src/processFunctions/init.ts
@@ -18,6 +18,7 @@ import {
 import { getExistingConfiguration } from '../helpers';
 import { writeConfigFileAndUpdateGitIgnore } from './sharedFunctions';
 import { additionalQuestionsDatabase } from './initFunctions/additionalQuestionsDatabase';
+import { PROCESS_ARGUMENT_PARAMS } from '../constants';
 
 /**
  * Initialises the application by adding asking the user questions,
@@ -53,8 +54,11 @@ export async function init(
   // Get a copy of the default config file
   const newConfig = { ...DEFAULT_CONFIG };
 
-  // Check if the defaults flag (--default) have been provided
-  if (params.includes('--default')) {
+  // Check if the defaults flag has been provided
+  if (
+    params.includes(PROCESS_ARGUMENT_PARAMS.DEFAULT) ||
+    params.includes(PROCESS_ARGUMENT_PARAMS.DEFAULT_SHORT)
+  ) {
     logger.info('Creating configuration file with default values');
     writeConfigFileAndUpdateGitIgnore(
       currentWorkingDirectory,

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autographcraft/mongodb",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The MongoDB resolver plugin for AutoGraphCraft",
   "main": "./dist/commonjs/app.js",
   "module": "./dist/esm/app.js",


### PR DESCRIPTION
Added `--clean-models` flag to enable the deletion of models that have been removed from the schema.  Without this functionality, the deleted models would sit in the generated folders and the models folder, cluttering up the local builds.
